### PR TITLE
Add sentiment-bot config details

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -19,3 +19,14 @@ firstPRMergeComment: >
   Congrats on merging your first pull request! We here at WHO appreciate your time and contribution!
 
 # It is recommended to include as many gifs and emojis as possible!
+
+
+# Configuration for sentiment-bot - https://github.com/behaviorbot/sentiment-bot
+
+# *Required* toxicity threshold between 0 and .99 with the higher numbers being the most toxic
+# Anything higher than this threshold will be marked as toxic and commented on
+sentimentBotToxicityThreshold: .7
+
+# *Required* Comment to reply with
+sentimentBotReplyComment: >
+  While we appreciate your feedback, please be sure to review the [Code of Conduct](https://github.com/WorldHealthOrganization/open-source-communication-channel/blob/main/CODE_OF_CONDUCT.md) and be respectful of other users in your comments. cc/ @milovanovicdusan 


### PR DESCRIPTION
This PR adds configuration detail for the sentiment-bot to mark comments that are potentially deemed toxic