### PR TITLE
Add guidance on GitHub repos

### DIFF
--- a/docs/guidance/new_github_repo.md
+++ b/docs/guidance/new_github_repo.md
@@ -28,7 +28,7 @@ Follow the [GitHub documentation](https://docs.github.com/en/authentication/secu
 
 ### Link to WHO WIMS account
 
-For WHO members, you may require an additional step to link your GitHub account using single sign on. See (instructions)[https://extranet.who.int/confluence/display/github/GitHub+Standards].
+For WHO members, you may require an additional step to link your GitHub account using single sign on. See [instructions](https://extranet.who.int/confluence/display/github/GitHub+Standards).
 
 <br>
 

--- a/docs/guidance/new_github_repo.md
+++ b/docs/guidance/new_github_repo.md
@@ -2,17 +2,17 @@
 
 ## What is GitHub?
 
-GitHub offers products for storing and collaborating on code.
+GitHub offers products for storing and collaborating on source code.
 
-The World Health Organization has a GitHub Enterprise account that can be viewed at [github.com/WorldHealthOrganization](https://github.com/WorldHealthOrganization).
+The World Health Organization's verified GitHub organisation can be viewed at [github.com/WorldHealthOrganization](https://github.com/WorldHealthOrganization).
 
 Read [more about enterprise accounts](https://docs.github.com/en/enterprise-cloud@latest/admin/overview/about-enterprise-accounts).
 
-## Creating a GitHub User Account
+## Creating a GitHub Personal User Account
 
-A GitHub account is needed to contribute code, open issues, or participate in discussion on GitHub repositories. 
+A personal GitHub account is needed to contribute code, open issues, or participate in discussion on GitHub repositories. 
 
-Go to [github.com](https://github.com/) and sign up for a GitHub account using your email.
+Go to [github.com](https://github.com/) and sign up for a personal GitHub account using your email.
 
 <br>
 

--- a/docs/guidance/new_github_repo.md
+++ b/docs/guidance/new_github_repo.md
@@ -1,0 +1,50 @@
+# Setting up a GitHub Repository
+
+## What is GitHub?
+
+GitHub offers products for storing and collaborating on code.
+
+The World Health Organization has a GitHub Enterprise account that can be viewed at [github.com/WorldHealthOrganization](https://github.com/WorldHealthOrganization).
+
+Read [more about enterprise accounts](https://docs.github.com/en/enterprise-cloud@latest/admin/overview/about-enterprise-accounts).
+
+## Creating a GitHub User Account
+
+A GitHub account is needed to contribute code, open issues, or participate in discussion on GitHub repositories. 
+
+Go to [github.com](https://github.com/) and sign up for a GitHub account using your email.
+
+<br>
+
+> ℹ **Note:** You can use your personal email address, especially if you would like to maintain a history of your GitHub activity beyond your current organization.
+
+<br>
+
+### Two-factor Authentication
+
+Two-factor authentication (2FA) adds an important layer of protection to make your account more secure.
+
+Follow the [GitHub documentation](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication) on enabling 2FA.
+
+### Link to WHO WIMS account
+
+For WHO members, you may require an additional step to link your GitHub account using single sign on. See (instructions)[https://extranet.who.int/confluence/display/github/GitHub+Standards].
+
+<br>
+
+> ℹ **Note:** Collaborators without a WHO account can still be invited as collaborators.
+
+<br>
+
+### Requesting a WHO GitHub Repository
+
+WHO members can request a new repository using the [self service portal](https://who.service-now.com/self_service?id=sc_cat_item&sys_id=87bc6f40db1c9090a10ba7c748961988).
+
+
+### Repository Best Practices
+
+- Use lower case words connected with hyphens for your repository name
+- The repository name should be short but descriptive (<50 characters)
+- Avoid special characters or spaces in a repository name
+- Add a brief description of the purpose for the repository
+- Add [topics](https://github.blog/2017-01-31-introducing-topics/) to your repository details

--- a/docs/guidance/starting_open_source_project.md
+++ b/docs/guidance/starting_open_source_project.md
@@ -16,7 +16,7 @@ GitHub's [opensource.guide](https://opensource.guide/starting-a-project/) provid
 
 #### Documentation
 
-✔ GitHub repository - the WHO has adopted GitHub as the standard code repository for software projects
+✔ GitHub repository - the [WHO has adopted GitHub](new_github_repo.md) as the standard code repository for software projects
 
 ✔ License - add a LICENSE file containing your chosen open source license to your project
 


### PR DESCRIPTION
Internal guidance exists within the WHO intranet. This PR summarizes the guidance and contextualizes it for open sharing.