### PR TITLE
add support request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/support-request.md
+++ b/.github/ISSUE_TEMPLATE/support-request.md
@@ -1,0 +1,27 @@
+---
+name: Support Request
+about: Use this template for issue about requesting support from the Open Source Program Office (WHO projects)
+title: Support Request for Project
+labels: support request
+assignees: '@smbuthia'
+
+---
+
+## Please fill the following information
+
+1. Category of support requested: 
+- [ ] Choosing an open source licensing (outbound)
+- [ ] Open source license compliance (inbound)
+- [ ] Building a community of contributors
+- [ ] Open source governance for a project
+- [ ] Managing open source contributions
+
+2. Type of support proposed: 
+- [ ] Guides or available policies
+- [ ] Advice or accompaniment 
+- [ ] Direct input (may not always be possible)
+- [ ] Other
+
+3. Additional context or information about the project:
+
+ *Note: Do not disclose any information that you don't want made public.*


### PR DESCRIPTION
This PR creates a first version template for project teams to easily request support from the OSPO. We could add more fields or remove unnecessary ones as useful.

Resolves #74 