### PR TITLE
Add guide on making internal repo public

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -3,6 +3,7 @@
   - [Starting an Open Source Project](starting_open_source_project.md)
   - [Choosing an Open Source License](choosing_a_license.md)
   - [Setting up a GitHub Repository](new_github_repo.md)
+  - [Making an Internal GitHub Repository Public](making_internal_repo_public.md)
 
 - Building Contributor Communities
   - [Why Build a Community and Where to Start](building_community_intro.md)

--- a/docs/guidance/making_internal_repo_public.md
+++ b/docs/guidance/making_internal_repo_public.md
@@ -1,0 +1,41 @@
+# Making an Internal GitHub Repository Public
+
+## 📃 Open Source Checklist
+
+You may want to make an internal repository public so that the work within it is available to everyone including those who do not have direct access to the repository. It is recommended that only repositories that have been licensed as open source be made public.
+
+### Must have:
+
+✅ An open source [LICENSE](choosing_a_license.md#license-reference) file
+
+✅ A [copyright notice](choosing_a_license.md#copyright-notice)
+
+### Recommended to have:
+
+☑ A [README](sample_readme.md) file
+
+☑ A [CONTRIBUTING](developing_contribution_guide.md) guide
+
+☑ A community [CODE_OF_CONDUCT](https://github.com/WorldHealthOrganization/open-source-communication-channel/blob/main/CODE_OF_CONDUCT.md ':target=_blank') 
+
+## 🔐 Security Checklist
+
+It is critical to ensure that there is no sensitive material in the code files, documentation, history, issues, pull requests, or discussions before you make an internal repository public. The best approach to ensure that no sensitive material is shared in code files, documentation, issues, pull requests or discussions even when the repository is internal.
+
+✅ Add [branch protection rules](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches ':target=_blank') to maintain control over contributions to the main branch.
+
+✅ Review all code and remove any hard-coded sensitive information like passwords and emails. Note that the information may still be contained in the file's history even after deletion. 
+
+> 📖 **Read more:** [Removing sensitive information from a repository](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository ':target=_blank')
+
+> ❗ **Once you have pushed a commit to GitHub, you should consider any sensitive data in the commit compromised. If you have committed a password, you should change it. If you have committed a key, generate a new one. Removing the compromised data doesn't resolve its initial exposure, especially in existing clones or forks of your repository.**
+
+☑ Add [tools for code scanning](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/about-code-scanning#about-tools-for-code-scanning ':target=_blank') to your workflow.
+
+## 🔗 Links to Useful Resources
+
+- [Code security guides](https://docs.github.com/en/code-security/guides)
+
+## 💬 How the Open Source Progamme Office Can Support Your Work
+
+If you have questions, would like to make an existing project open source, or start a new project that you would like to be open source, please reach out on [Discussions](https://github.com/WorldHealthOrganization/open-source-communication-channel/discussions).


### PR DESCRIPTION
This pull request adds a new guide that provides a simple checklist to follow before making an internal GitHub repository public.

Resolves #85 